### PR TITLE
added necessary requirements to run the app out of the box

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,16 @@
--i https://pypi.org/simple
 certifi==2019.6.16
 chardet==3.0.4
 defusedxml==0.6.0
+Django==2.2.5
 django-allauth==0.40.0
-django==2.2.5
+django-crispy-forms==1.9.0
 idna==2.8
 oauthlib==3.1.0
-pillow==6.2.0
+Pillow==6.2.0
 python3-openid==3.1.0
 pytz==2019.2
-requests-oauthlib==1.2.0
 requests==2.22.0
+requests-oauthlib==1.2.0
 sqlparse==0.3.0
+stripe==2.43.0
 urllib3==1.25.3


### PR DESCRIPTION
There were some missing packages in `requirements.txt`.
1. [Django-crispy-forms](https://pypi.python.org/pypi/django-crispy-forms)
2. [Stripe](https://pypi.org/project/stripe/)